### PR TITLE
Add declaration of the `c2hs` dependency

### DIFF
--- a/hsshellscript.cabal
+++ b/hsshellscript.cabal
@@ -88,6 +88,7 @@ Library
                       unix >= 2.7.2 && < 2.8,
                       parsec >= 3.1.14 && < 3.2,
                       random >= 1.1 && < 1.2
+  Build-Tool-Depends: c2hs:c2hs
   hs-source-dirs:     src
   C-Sources:          src/cbits/hsshellscript.c
   default-language:   Haskell2010


### PR DESCRIPTION
The `hsshellscript` library requires `c2hs` as a build tool, but this dependency is not specified, resulting in build failures, at least when `c2hs` is not available otherwise. This pull request fixes this.